### PR TITLE
[Feature] 독서 토론 생성, 독서 토론 리스트 조회 기능 구현

### DIFF
--- a/src/book-discussions/book-discussions.controller.spec.ts
+++ b/src/book-discussions/book-discussions.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookDiscussionsController } from './book-discussions.controller';
+import { BookDiscussionsService } from './book-discussions.service';
+
+describe('BookDiscussionsController', () => {
+  let controller: BookDiscussionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BookDiscussionsController],
+      providers: [BookDiscussionsService],
+    }).compile();
+
+    controller = module.get<BookDiscussionsController>(
+      BookDiscussionsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/book-discussions/book-discussions.controller.ts
+++ b/src/book-discussions/book-discussions.controller.ts
@@ -14,6 +14,7 @@ import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { Public } from 'src/auth/decorators/public.decorator';
 import UserRequest from 'src/auth/types/user-request.interface';
+import { PaginationQueryDto } from 'src/shared/dto/pagenation-query.dto';
 import { BookDiscussionsService } from './book-discussions.service';
 import { CreateBookDiscussionDto } from './dto/create-book-discussion.dto';
 import { UpdateBookDiscussionDto } from './dto/update-book-discussion.dto';
@@ -43,14 +44,14 @@ export class BookDiscussionsController {
   @ApiQuery({ name: 'limit', type: Number, required: true })
   @ApiQuery({ name: 'page', type: Number, required: true })
   async findAll(
-    @Query('limit', ParseIntPipe) limit = 10,
-    @Query('page', ParseIntPipe) page = 1,
+    @Query() paginationQueryDto: PaginationQueryDto,
     @Req() request: UserRequest,
   ) {
+    const { page, limit } = paginationQueryDto;
     const offset = (page - 1) * limit;
-    console.log(limit, page);
+
     const { posts, totalCount } = await this.bookDiscussionsService.findAll(
-      limit,
+      Number(limit),
       offset,
     );
 

--- a/src/book-discussions/book-discussions.controller.ts
+++ b/src/book-discussions/book-discussions.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Req,
+  Query,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Public } from 'src/auth/decorators/public.decorator';
+import UserRequest from 'src/auth/types/user-request.interface';
+import { BookDiscussionsService } from './book-discussions.service';
+import { CreateBookDiscussionDto } from './dto/create-book-discussion.dto';
+import { UpdateBookDiscussionDto } from './dto/update-book-discussion.dto';
+
+@Controller('book-discussions')
+@ApiTags('book-discussions')
+export class BookDiscussionsController {
+  constructor(
+    private readonly bookDiscussionsService: BookDiscussionsService,
+  ) {}
+
+  @Post()
+  @ApiBearerAuth()
+  async create(
+    @Body() createBookDiscussionDto: CreateBookDiscussionDto,
+    @Req() request: UserRequest,
+  ) {
+    return this.bookDiscussionsService.create(
+      createBookDiscussionDto,
+      request.user.id,
+    );
+  }
+
+  // @ApiBearerAuth()
+  @Public()
+  @Get()
+  @ApiQuery({ name: 'limit', type: Number, required: true })
+  @ApiQuery({ name: 'page', type: Number, required: true })
+  async findAll(
+    @Query('limit', ParseIntPipe) limit = 10,
+    @Query('page', ParseIntPipe) page = 1,
+    @Req() request: UserRequest,
+  ) {
+    return await this.bookDiscussionsService.findAll(limit, page);
+  }
+
+  @Public()
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number, @Req() request: UserRequest) {
+    return this.bookDiscussionsService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateBookDiscussionDto: UpdateBookDiscussionDto,
+  ) {
+    return this.bookDiscussionsService.update(id, updateBookDiscussionDto);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.bookDiscussionsService.remove(id);
+  }
+}

--- a/src/book-discussions/book-discussions.controller.ts
+++ b/src/book-discussions/book-discussions.controller.ts
@@ -47,7 +47,22 @@ export class BookDiscussionsController {
     @Query('page', ParseIntPipe) page = 1,
     @Req() request: UserRequest,
   ) {
-    return await this.bookDiscussionsService.findAll(limit, page);
+    const offset = (page - 1) * limit;
+    console.log(limit, page);
+    const { posts, totalCount } = await this.bookDiscussionsService.findAll(
+      limit,
+      offset,
+    );
+
+    return {
+      posts,
+      pagesInfo: {
+        page,
+        totalCount,
+        currentCount: posts.length,
+        totalPage: Math.ceil(totalCount / limit),
+      },
+    };
   }
 
   @Public()

--- a/src/book-discussions/book-discussions.module.ts
+++ b/src/book-discussions/book-discussions.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BookDiscussionsService } from './book-discussions.service';
+import { BookDiscussionsController } from './book-discussions.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  controllers: [BookDiscussionsController],
+  providers: [BookDiscussionsService],
+  imports: [PrismaModule],
+})
+export class BookDiscussionsModule {}

--- a/src/book-discussions/book-discussions.service.spec.ts
+++ b/src/book-discussions/book-discussions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookDiscussionsService } from './book-discussions.service';
+
+describe('BookDiscussionsService', () => {
+  let service: BookDiscussionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BookDiscussionsService],
+    }).compile();
+
+    service = module.get<BookDiscussionsService>(BookDiscussionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/book-discussions/book-discussions.service.ts
+++ b/src/book-discussions/book-discussions.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { CreateBookDiscussionDto } from './dto/create-book-discussion.dto';
+import { UpdateBookDiscussionDto } from './dto/update-book-discussion.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { Post, BookDiscussion, Book } from '@prisma/client';
+
+@Injectable()
+export class BookDiscussionsService {
+  constructor(private prisma: PrismaService) {}
+
+  convertPostToReposnse(
+    post: Post & {
+      BookDiscussion: (BookDiscussion & {
+        Book: Book;
+      })[];
+    },
+  ) {
+    return {
+      id: post.id,
+      authorId: post.authorId,
+      title: post.title,
+      content: post.content,
+      views: post.views,
+      thumbup: post.thumbup,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt.toISOString(),
+      book: post.BookDiscussion[0].Book,
+    };
+  }
+
+  async create(
+    createBookDiscussionDto: CreateBookDiscussionDto,
+    authorId: number,
+  ) {
+    let book = await this.prisma.book.findUnique({
+      where: { ibsn: createBookDiscussionDto.book.ibsn },
+    });
+
+    if (!book) {
+      book = await this.prisma.book.create({
+        data: createBookDiscussionDto.book,
+      });
+    }
+
+    const post = await this.prisma.post.create({
+      data: {
+        authorId,
+        title: createBookDiscussionDto.title,
+        content: createBookDiscussionDto.content,
+        BookDiscussion: {
+          create: {
+            bookId: book.id,
+          },
+        },
+      },
+      include: {
+        BookDiscussion: {
+          include: {
+            Book: true,
+          },
+        },
+      },
+    });
+
+    return this.convertPostToReposnse(post);
+  }
+
+  async findAll(limit: number, offset: number) {
+    return `This action findAll a #${limit} ${offset} bookDiscussion`;
+  }
+
+  async findOne(id: number) {
+    return this.prisma.user.findUnique({ where: { id } });
+  }
+
+  async update(id: number, updateBookDiscussionDto: UpdateBookDiscussionDto) {
+    return `This action updates a #${id} bookDiscussion`;
+  }
+
+  async remove(id: number) {
+    return `This action removes a #${id} bookDiscussion`;
+  }
+}

--- a/src/book-discussions/book-discussions.service.ts
+++ b/src/book-discussions/book-discussions.service.ts
@@ -66,7 +66,22 @@ export class BookDiscussionsService {
   }
 
   async findAll(limit: number, offset: number) {
-    return `This action findAll a #${limit} ${offset} bookDiscussion`;
+    const [posts, totalCount] = await this.prisma.$transaction([
+      this.prisma.post.findMany({
+        take: limit,
+        skip: offset,
+        include: {
+          BookDiscussion: {
+            include: {
+              Book: true,
+            },
+          },
+        },
+      }),
+      this.prisma.bookDiscussion.count(),
+    ]);
+
+    return { posts: posts.map(this.convertPostToReposnse), totalCount };
   }
 
   async findOne(id: number) {

--- a/src/book-discussions/dto/create-book-discussion.dto.ts
+++ b/src/book-discussions/dto/create-book-discussion.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+
+export class bookDto {
+  @IsNotEmpty()
+  @IsNumber()
+  @ApiProperty()
+  ibsn: number;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  title: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  author: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  translator: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  description: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  url: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  image: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  publisher: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  pubdate: Date;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty()
+  category: string;
+}
+
+export class CreateBookDiscussionDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty()
+  content: string;
+
+  @ValidateNested()
+  @Type(() => bookDto)
+  @ApiProperty({
+    type: bookDto,
+  })
+  book: bookDto;
+}

--- a/src/book-discussions/entities/book-discussion.entity.ts
+++ b/src/book-discussions/entities/book-discussion.entity.ts
@@ -1,0 +1,1 @@
+export class BookDiscussion {}

--- a/src/shared/dto/pagenation-query.dto.ts
+++ b/src/shared/dto/pagenation-query.dto.ts
@@ -1,0 +1,18 @@
+import { Transform, Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min, Max } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page = 1;
+
+  @IsOptional()
+  @IsNumber()
+  @Type(() => Number)
+  @Transform(({ value }) => parseInt(value, 10))
+  @Min(1)
+  @Max(50)
+  limit = 10;
+}


### PR DESCRIPTION
### 개발내용
- #11 
- 독서 토론 생성 기능 구현
- 독서 토론 조회 기능 구현


### 고민사항 
- 페이지 네이션기반 독서 토론 리스트 조회 vs 커서 기반 독서 토론 리스트 조회
  - 페이지 네이션 기반은 시작지점을 찾아야 하기 때문에 양이 많아질수록 조회하는데 성능저하가 발생할 수 있음
  - 커서 기반은 특정(마지막) id로 바로 접근하기 때문에 양에 따른 성능저하 현상이 없음
  - 하지만 신규 데이터가 있을 경우에 대해 이를 인지하고 처리하는데 오히려 복잡도가 높아짐 
  - 현재 데이터 양이 많지 않기 떄문에, 성능저하 보다는 코드 복잡도를 낮추는게 좋다고 판단되어 페이지 네이션 기반으로 구현하기로 결정
  - 커서 기반은 무한스크롤에 적합해보임
  - 참고: [prisma - pagenation 파트](https://www.prisma.io/docs/concepts/components/prisma-client/pagination)