### PR TITLE
[Feature] post OwnershipGuard 구현, book-discussions 삭제 기능 구현

### DIFF
--- a/src/book-discussions/book-discussions.controller.ts
+++ b/src/book-discussions/book-discussions.controller.ts
@@ -9,25 +9,26 @@ import {
   Req,
   Query,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { Request } from 'express';
 import { Public } from 'src/auth/decorators/public.decorator';
 import UserRequest from 'src/auth/types/user-request.interface';
+import { OwnershipGuard } from 'src/posts/guards/ownership.guard';
 import { PaginationQueryDto } from 'src/shared/dto/pagenation-query.dto';
 import { BookDiscussionsService } from './book-discussions.service';
 import { CreateBookDiscussionDto } from './dto/create-book-discussion.dto';
 import { UpdateBookDiscussionDto } from './dto/update-book-discussion.dto';
 
-@Controller('book-discussions')
 @ApiTags('book-discussions')
+@Controller('book-discussions')
 export class BookDiscussionsController {
   constructor(
     private readonly bookDiscussionsService: BookDiscussionsService,
   ) {}
 
-  @Post()
   @ApiBearerAuth()
+  @Post()
   async create(
     @Body() createBookDiscussionDto: CreateBookDiscussionDto,
     @Req() request: UserRequest,
@@ -39,10 +40,10 @@ export class BookDiscussionsController {
   }
 
   // @ApiBearerAuth()
-  @Public()
-  @Get()
   @ApiQuery({ name: 'limit', type: Number, required: true })
   @ApiQuery({ name: 'page', type: Number, required: true })
+  @Public()
+  @Get()
   async findAll(
     @Query() paginationQueryDto: PaginationQueryDto,
     @Req() request: UserRequest,
@@ -68,12 +69,13 @@ export class BookDiscussionsController {
 
   @Public()
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number, @Req() request: UserRequest) {
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.bookDiscussionsService.findOne(id);
   }
 
-  @Patch(':id')
   @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(OwnershipGuard)
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateBookDiscussionDto: UpdateBookDiscussionDto,
@@ -81,8 +83,9 @@ export class BookDiscussionsController {
     return this.bookDiscussionsService.update(id, updateBookDiscussionDto);
   }
 
-  @Delete(':id')
   @ApiBearerAuth()
+  @Delete(':id')
+  @UseGuards(OwnershipGuard)
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.bookDiscussionsService.remove(id);
   }

--- a/src/book-discussions/book-discussions.module.ts
+++ b/src/book-discussions/book-discussions.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { BookDiscussionsService } from './book-discussions.service';
 import { BookDiscussionsController } from './book-discussions.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { PostsService } from 'src/posts/posts.service';
 
 @Module({
   controllers: [BookDiscussionsController],
-  providers: [BookDiscussionsService],
+  providers: [BookDiscussionsService, PostsService],
   imports: [PrismaModule],
 })
 export class BookDiscussionsModule {}

--- a/src/book-discussions/book-discussions.service.ts
+++ b/src/book-discussions/book-discussions.service.ts
@@ -2,18 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { CreateBookDiscussionDto } from './dto/create-book-discussion.dto';
 import { UpdateBookDiscussionDto } from './dto/update-book-discussion.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
-import {
-  Post,
-  BookDiscussion,
-  Book,
-  User,
-  Comment,
-  CommentLike,
-} from '@prisma/client';
+import { Post, BookDiscussion, Book, Comment } from '@prisma/client';
+import { PostsService } from 'src/posts/posts.service';
 
 @Injectable()
 export class BookDiscussionsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private postService: PostsService,
+  ) {}
 
   convertPostToReposnse(
     post: Post & {
@@ -219,6 +216,6 @@ export class BookDiscussionsService {
   }
 
   async remove(id: number) {
-    return `This action removes a #${id} bookDiscussion`;
+    return this.postService.remove(id);
   }
 }

--- a/src/book-discussions/dto/update-book-discussion.dto.ts
+++ b/src/book-discussions/dto/update-book-discussion.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateBookDiscussionDto } from './create-book-discussion.dto';
+
+export class UpdateBookDiscussionDto extends PartialType(
+  CreateBookDiscussionDto,
+) {}

--- a/src/posts/guards/ownership.guard.ts
+++ b/src/posts/guards/ownership.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { PostsService } from '../posts.service';
+
+@Injectable()
+export class OwnershipGuard implements CanActivate {
+  constructor(private readonly postService: PostsService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const postId = Number(request.params.id); // 현재 요청의 파라미터에서 post id 추출
+
+    // PostService를 통해 post 소유 여부 체크
+    const isOwner = await this.postService.checkOwnership(postId, request.user);
+    return isOwner;
+  }
+}

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { PostsService } from './posts.service';
+
+@Module({
+  providers: [PostsService],
+  exports: [PostsService],
+  imports: [PrismaModule],
+})
+export class PostsModule {}

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostsService } from './posts.service';
+
+describe('PostsService', () => {
+  let service: PostsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostsService],
+    }).compile();
+
+    service = module.get<PostsService>(PostsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,0 +1,34 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { User } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class PostsService {
+  constructor(private prisma: PrismaService) {}
+
+  async findOne(id: number) {
+    return this.prisma.post.findUnique({ where: { id } });
+  }
+
+  async remove(id: number) {
+    return this.prisma.post.delete({ where: { id } });
+  }
+
+  async checkOwnership(id: number, user: User) {
+    const post = await this.findOne(id); // Prisma를 사용하여 게시물 조회
+
+    if (!post) {
+      throw new NotFoundException('게시물을 찾을 수 없습니다.');
+    }
+
+    if (post.authorId !== user.id) {
+      throw new ForbiddenException('본인의 게시물만 수정할 수 있습니다.');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
### 개발내용
- posts serivce 구현
  -  book-discussions service와 pro-con-discussions에서 공통적으로 사용하기 위해 구현
  - findOne, remove, checkOwnership 구현
- OwnershipGuard 구현
  - 본인 계정의 게시글이 아닌 경우: 403 error
  - 게시글이 존재하지 않는 경우: 404 error
  - 수정과 삭제에 Guard 사용
- book-discussions 삭제 기능 추가
