### PR TITLE
[Feature] 찬성반대 게시글 기능 구현, 댓글 좋아요, 싫어요 기능 수정

### DIFF
--- a/src/modules/comments-dislike/comments-dislike.service.ts
+++ b/src/modules/comments-dislike/comments-dislike.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   forwardRef,
   Inject,
   Injectable,
@@ -18,6 +19,11 @@ export class CommentsDislikeService {
 
   async create(createCommentsDislikeDto: CreateCommentsDislikeDto) {
     const { commentId, userId } = createCommentsDislikeDto;
+    const commentDislike = await this.findOne(commentId, userId);
+
+    if (commentDislike) {
+      throw new ConflictException('이미 싫어요한 댓글입니다.');
+    }
 
     await this.commentsLikeService.findAndRemove(commentId, userId);
 
@@ -54,7 +60,7 @@ export class CommentsDislikeService {
   }
 
   async removeThrow(commentId: number, userId: number) {
-    const commentDislike = await this.findOne(userId, commentId);
+    const commentDislike = await this.findOne(commentId, userId);
 
     if (!commentDislike) {
       throw new NotFoundException('CommentDislike not found');

--- a/src/modules/comments-like/comments-like.service.ts
+++ b/src/modules/comments-like/comments-like.service.ts
@@ -1,5 +1,6 @@
 import { CommentsDislikeService } from '../comments-dislike/comments-dislike.service';
 import {
+  ConflictException,
   forwardRef,
   Inject,
   Injectable,
@@ -18,6 +19,12 @@ export class CommentsLikeService {
 
   async create(createCommentsLikeDto: CreateCommentsLikeDto) {
     const { commentId, userId } = createCommentsLikeDto;
+
+    const commentLike = await this.findOne(commentId, userId);
+
+    if (commentLike) {
+      throw new ConflictException('이미 좋아요한 댓글입니다.');
+    }
 
     await this.commentsDislikeService.findAndRemove(commentId, userId);
 
@@ -56,7 +63,7 @@ export class CommentsLikeService {
   }
 
   async removeThrow(commentId: number, userId: number) {
-    const commentLike = await await this.findOne(userId, commentId);
+    const commentLike = await this.findOne(commentId, userId);
 
     if (!commentLike) {
       throw new NotFoundException('CommentLike not found');

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -48,7 +48,7 @@ export class CommentsController {
     return this.commentsService.create(
       createCommentDto,
       postId,
-      Number(request.user.id),
+      request.user.id,
     );
   }
 
@@ -97,8 +97,13 @@ export class CommentsController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateCommentDto: UpdateCommentDto,
+    @Req() request: UserRequest,
   ) {
-    return await this.commentsService.update(updateCommentDto, id);
+    return await this.commentsService.update(
+      updateCommentDto,
+      id,
+      request.user.id,
+    );
   }
 
   @HttpCode(204)

--- a/src/modules/comments/dto/update-comment.dto.ts
+++ b/src/modules/comments/dto/update-comment.dto.ts
@@ -1,0 +1,8 @@
+import { CreateCommentDto } from './create-comment.dto';
+
+export class UpdateCommentDto extends CreateCommentDto {
+  // @ApiProperty()
+  // @IsString()
+  // @IsNotEmpty()
+  // content: string;
+}

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -11,7 +11,13 @@ export class PostsService {
   constructor(private prisma: PrismaService) {}
 
   async findOne(id: number) {
-    return this.prisma.post.findUnique({ where: { id } });
+    return this.prisma.post.findUnique({
+      where: { id },
+      include: {
+        ProConDiscussion: true,
+        BookDiscussion: true,
+      },
+    });
   }
 
   async remove(id: number) {

--- a/src/modules/pro-con-discussions/dto/create-pro-con-discussion.dto.ts
+++ b/src/modules/pro-con-discussions/dto/create-pro-con-discussion.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty } from 'class-validator';
+import { CreatePostDto } from 'src/modules/posts/dto/create-posts.dto';
+
+export class CreateProConDiscussionDto extends CreatePostDto {
+  @ApiProperty()
+  @IsBoolean()
+  @IsNotEmpty()
+  isAgree: boolean;
+}

--- a/src/modules/pro-con-discussions/dto/update-pro-con-discussion.dto.ts
+++ b/src/modules/pro-con-discussions/dto/update-pro-con-discussion.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProConDiscussionDto } from './create-pro-con-discussion.dto';
+
+export class UpdateProConDiscussionDto extends PartialType(
+  CreateProConDiscussionDto,
+) {}

--- a/src/modules/pro-con-discussions/pro-con-discussions.controller.spec.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProConDiscussionsController } from './pro-con-discussions.controller';
+import { ProConDiscussionsService } from './pro-con-discussions.service';
+
+describe('ProConDiscussionsController', () => {
+  let controller: ProConDiscussionsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProConDiscussionsController],
+      providers: [ProConDiscussionsService],
+    }).compile();
+
+    controller = module.get<ProConDiscussionsController>(
+      ProConDiscussionsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Req,
+  Query,
+  ParseIntPipe,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ProConDiscussionsService } from './pro-con-discussions.service';
+import { CreateProConDiscussionDto } from './dto/create-pro-con-discussion.dto';
+import { UpdateProConDiscussionDto } from './dto/update-pro-con-discussion.dto';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import UserRequest from 'src/modules/auth/types/user-request.interface';
+import { Public } from 'src/modules/auth/decorators/public.decorator';
+import { PaginationQueryDto } from 'src/shared/dto/pagenation-query.dto';
+import { OwnershipGuard } from 'src/modules/posts/guards/ownership.guard';
+import { AuthService } from '../auth/auth.service';
+
+@ApiTags('pro-con-discussions')
+@Controller('pro-con-discussions')
+export class ProConDiscussionsController {
+  constructor(
+    private readonly proConDiscussionsService: ProConDiscussionsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @ApiBearerAuth()
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createProConDiscussionDto: CreateProConDiscussionDto,
+    @Req() request: UserRequest,
+  ) {
+    return await this.proConDiscussionsService.create(
+      createProConDiscussionDto,
+      request.user.id,
+    );
+  }
+
+  @ApiQuery({ name: 'limit', type: Number, required: true })
+  @ApiQuery({ name: 'page', type: Number, required: true })
+  @Public()
+  @Get()
+  async findAll(@Query() paginationQueryDto: PaginationQueryDto) {
+    const { page, limit } = paginationQueryDto;
+    const offset = (page - 1) * limit;
+    const { posts, totalCount } = await this.proConDiscussionsService.findAll(
+      Number(limit),
+      offset,
+    );
+    return {
+      posts,
+      pagesInfo: {
+        page,
+        totalCount,
+        currentCount: posts.length,
+        totalPage: Math.ceil(totalCount / limit),
+      },
+    };
+  }
+
+  @ApiBearerAuth()
+  @Public()
+  @Get(':id')
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() request: UserRequest,
+  ) {
+    const token = request.headers.authorization?.replace('Bearer ', '');
+    const user = await this.authService.getUserFromToken(token);
+
+    return await this.proConDiscussionsService.findOne(id, user?.id || -1);
+  }
+
+  @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(OwnershipGuard)
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateProConDiscussionDto: UpdateProConDiscussionDto,
+    @Req() request: UserRequest,
+  ) {
+    return this.proConDiscussionsService.update(
+      id,
+      updateProConDiscussionDto,
+      request.user.id,
+    );
+  }
+
+  @ApiBearerAuth()
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(OwnershipGuard)
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.proConDiscussionsService.remove(id);
+  }
+}

--- a/src/modules/pro-con-discussions/pro-con-discussions.module.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.module.ts
@@ -1,0 +1,22 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { ProConDiscussionsService } from './pro-con-discussions.service';
+import { ProConDiscussionsController } from './pro-con-discussions.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { PostsModule } from 'src/modules/posts/posts.module';
+import { ProConVoteModule } from '../pro-con-vote/pro-con-vote.module';
+import { CommentsModule } from '../comments/comments.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  controllers: [ProConDiscussionsController],
+  providers: [ProConDiscussionsService],
+  imports: [
+    PrismaModule,
+    PostsModule,
+    AuthModule,
+    forwardRef(() => CommentsModule),
+    forwardRef(() => ProConVoteModule),
+  ],
+  exports: [ProConDiscussionsService],
+})
+export class ProConDiscussionsModule {}

--- a/src/modules/pro-con-discussions/pro-con-discussions.service.spec.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProConDiscussionsService } from './pro-con-discussions.service';
+
+describe('ProConDiscussionsService', () => {
+  let service: ProConDiscussionsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProConDiscussionsService],
+    }).compile();
+
+    service = module.get<ProConDiscussionsService>(ProConDiscussionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/pro-con-discussions/pro-con-discussions.service.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.service.ts
@@ -1,0 +1,248 @@
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Post, ProConDiscussion, ProConVote, Comment } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { PostsService } from '../posts/posts.service';
+import { ProConVoteService } from '../pro-con-vote/pro-con-vote.service';
+import { CreateProConDiscussionDto } from './dto/create-pro-con-discussion.dto';
+import { UpdateProConDiscussionDto } from './dto/update-pro-con-discussion.dto';
+
+@Injectable()
+export class ProConDiscussionsService {
+  constructor(
+    private prisma: PrismaService,
+    @Inject(forwardRef(() => ProConVoteService))
+    private proConVoteService: ProConVoteService,
+    private postService: PostsService,
+  ) {}
+
+  async convertPostToReposnse(
+    post: Post & {
+      ProConDiscussion: ProConDiscussion & {
+        ProConVote: ProConVote[];
+      };
+      User: {
+        username: string;
+      };
+      Comment: Comment[];
+    },
+  ) {
+    const agreeCount = await this.proConVoteService.agreeCount(
+      post.ProConDiscussion.id,
+    );
+    const disagreeCount = await this.proConVoteService.disagreeCount(
+      post.ProConDiscussion.id,
+    );
+    const [firstAgree, firstDisagree] =
+      await this.proConVoteService.findFirstVoteUsers(post.ProConDiscussion.id);
+
+    return {
+      id: post.id,
+      author: post.User.username,
+      title: post.title,
+      content: post.content,
+      views: post.views,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt.toISOString(),
+      agreeCount,
+      disagreeCount,
+      agreeUser: firstAgree?.User?.username || null,
+      disagreeUser: firstDisagree?.User?.username || null,
+      comments: post.Comment || [],
+    };
+  }
+
+  async create(
+    { title, content, isAgree }: CreateProConDiscussionDto,
+    authorId: number,
+  ) {
+    const post = await this.prisma.post.create({
+      data: {
+        authorId,
+        title,
+        content,
+        ProConDiscussion: {
+          create: {
+            ProConVote: {
+              create: {
+                isAgree,
+                userId: authorId,
+              },
+            },
+          },
+        },
+      },
+      include: {
+        ProConDiscussion: {
+          include: {
+            ProConVote: true,
+          },
+        },
+        User: {
+          select: {
+            username: true,
+          },
+        },
+        Comment: true,
+      },
+    });
+
+    console.log(post);
+
+    return this.convertPostToReposnse(post);
+  }
+
+  //ToDo: 대표 두명, 찬반 카운트
+  async findAll(limit: number, offset: number) {
+    const posts = await this.prisma.post.findMany({
+      where: {
+        NOT: { ProConDiscussion: null },
+      },
+      take: limit,
+      skip: offset,
+      include: {
+        ProConDiscussion: {
+          select: {
+            id: true,
+          },
+        },
+        User: {
+          select: {
+            username: true,
+          },
+        },
+      },
+    });
+
+    const totalCount = await this.prisma.proConDiscussion.count();
+    const convertPostToReposnse = posts.map(async (post) => {
+      const agreeCount = await this.proConVoteService.agreeCount(
+        post.ProConDiscussion.id,
+      );
+      const disagreeCount = await this.proConVoteService.disagreeCount(
+        post.ProConDiscussion.id,
+      );
+      const [firstAgree, firstDisagree] =
+        await this.proConVoteService.findFirstVoteUsers(
+          post.ProConDiscussion.id,
+        );
+
+      return {
+        id: post.id,
+        author: post.User.username,
+        title: post.title,
+        content: post.content,
+        views: post.views,
+        thumbup: post.thumbup,
+        createdAt: post.createdAt.toISOString(),
+        updatedAt: post.updatedAt.toISOString(),
+        agreeCount,
+        disagreeCount,
+        agreeUser: firstAgree?.User?.username || null,
+        disagreeUser: firstDisagree?.User?.username || null,
+      };
+    });
+
+    return {
+      posts: await Promise.all(convertPostToReposnse),
+      totalCount,
+    };
+  }
+
+  async findOne(id: number) {
+    const post = await this.prisma.post.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        ProConDiscussion: {
+          include: {
+            ProConVote: true,
+          },
+        },
+        User: {
+          select: {
+            username: true,
+          },
+        },
+        Comment: true,
+      },
+    });
+
+    if (!post.ProConDiscussion) {
+      throw new BadRequestException('찬성반대 토론 형태의 게시물이 아닙니다');
+    }
+    return this.convertPostToReposnse(post);
+  }
+
+  async findOneByPostId(postId: number) {
+    return await this.prisma.proConDiscussion.findUnique({
+      where: { postId },
+    });
+  }
+
+  async findOneByPostIdThrow(postId: number) {
+    const proConDiscussions = await this.prisma.proConDiscussion.findUnique({
+      where: { postId },
+    });
+
+    if (!proConDiscussions) {
+      throw new NotFoundException(
+        `[${postId}] 게시글이 없거나 찬반토론이 아닙니다`,
+      );
+    }
+
+    return proConDiscussions;
+  }
+
+  async update(
+    id: number,
+    { title, content, isAgree }: UpdateProConDiscussionDto,
+    authorId: number,
+  ) {
+    console.log(title);
+    if (isAgree !== undefined) {
+      console.log(
+        await this.proConVoteService.update({ isAgree }, authorId, id),
+      );
+    }
+
+    const post = await this.prisma.post.update({
+      where: {
+        id,
+      },
+      data: {
+        ...(title !== undefined && {
+          title: title,
+        }),
+        ...(content !== undefined && {
+          content: content,
+        }),
+      },
+      include: {
+        ProConDiscussion: {
+          include: {
+            ProConVote: true,
+          },
+        },
+        User: {
+          select: {
+            username: true,
+          },
+        },
+        Comment: true,
+      },
+    });
+
+    return this.convertPostToReposnse(post);
+  }
+
+  remove(id: number) {
+    return this.postService.remove(id);
+  }
+}


### PR DESCRIPTION
### 개발내용
- #28 
- #17 

### 개발 상세
- 찬성반대 게시글 기능 구현
  - 독서토론과 구분짓기 위해 post service에 관계 테이블 추가
  - 독서토론을 찬반토론에 요청한 경우 400  또는 404 오류
- 댓글 싫어요, 좋아요 수정 
  - 로그인된 계정의 좋아요, 싫어요 여부 추가
  - 중복시 409오류 추가
  - 잘 못 설정된 삭제 기능 수정 

