### PR TITLE
[Feature] 독서토론 여부 판단 추가, patch 댓글 누락 추가 

### DIFF
--- a/src/modules/book-discussions/book-discussions.controller.ts
+++ b/src/modules/book-discussions/book-discussions.controller.ts
@@ -53,8 +53,6 @@ export class BookDiscussionsController {
   ) {
     const token = request.headers.authorization?.replace('Bearer ', '');
     const user = await this.authService.getUserFromToken(token);
-
-    console.log(user);
     const { page, limit } = paginationQueryDto;
     const offset = (page - 1) * limit;
 
@@ -77,6 +75,7 @@ export class BookDiscussionsController {
 
   @Public()
   @Get(':id')
+  @ApiBearerAuth()
   async findOne(
     @Param('id', ParseIntPipe) id: number,
     @Req() request: UserRequest,


### PR DESCRIPTION
### 개발내용
- #11

### 개발 상세
- 게시글이 독서토론이 아닌경우 400 오류 발생
- 독서토론의 update patch의 누락된 댓글 내용추가
- isLikes에서 postLikedByUser 필드명 수정
- 불필요 로그 삭제