### PR TITLE
[Refactor] ProConDiscussions 순환 참조 삭제

### DIFF
--- a/src/modules/pro-con-discussions-helper/pro-con-discussions-helper.service.spec.ts
+++ b/src/modules/pro-con-discussions-helper/pro-con-discussions-helper.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProConDiscussionsHelperService } from './pro-con-discussions-helper.service';
+
+describe('ProConDiscussionsHelperService', () => {
+  let service: ProConDiscussionsHelperService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProConDiscussionsHelperService],
+    }).compile();
+
+    service = module.get<ProConDiscussionsHelperService>(
+      ProConDiscussionsHelperService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/pro-con-discussions-helper/pro-con-discussions-helper.service.ts
+++ b/src/modules/pro-con-discussions-helper/pro-con-discussions-helper.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ProConDiscussionsHelperService {
+  constructor(private prisma: PrismaService) {}
+
+  async findOneByPostId(postId: number) {
+    return await this.prisma.proConDiscussion.findUnique({
+      where: { postId },
+    });
+  }
+
+  async findOneByPostIdThrow(postId: number) {
+    const proConDiscussions = await this.prisma.proConDiscussion.findUnique({
+      where: { postId },
+    });
+
+    if (!proConDiscussions) {
+      throw new NotFoundException(
+        `[${postId}] 게시글이 없거나 찬반토론이 아닙니다`,
+      );
+    }
+
+    return proConDiscussions;
+  }
+}

--- a/src/modules/pro-con-discussions/pro-con-discussions.module.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.module.ts
@@ -14,8 +14,8 @@ import { AuthModule } from '../auth/auth.module';
     PrismaModule,
     PostsModule,
     AuthModule,
+    ProConVoteModule,
     forwardRef(() => CommentsModule),
-    forwardRef(() => ProConVoteModule),
   ],
   exports: [ProConDiscussionsService],
 })

--- a/src/modules/pro-con-discussions/pro-con-discussions.service.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.service.ts
@@ -18,11 +18,12 @@ export class ProConDiscussionsService {
   constructor(
     private prisma: PrismaService,
     private postService: PostsService,
-    @Inject(forwardRef(() => ProConVoteService))
     private proConVoteService: ProConVoteService,
     @Inject(forwardRef(() => CommentsService))
     private commentsService: CommentsService,
-  ) {}
+  ) {
+    this.convertPostToReposnse = this.convertPostToReposnse.bind(this);
+  }
 
   async convertPostToReposnse(
     post: Post & {
@@ -37,6 +38,7 @@ export class ProConDiscussionsService {
     const agreeCount = await this.proConVoteService.agreeCount(
       post.ProConDiscussion.id,
     );
+
     const disagreeCount = await this.proConVoteService.disagreeCount(
       post.ProConDiscussion.id,
     );

--- a/src/modules/pro-con-vote/pro-con-vote.module.ts
+++ b/src/modules/pro-con-vote/pro-con-vote.module.ts
@@ -1,13 +1,13 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ProConVoteService } from './pro-con-vote.service';
 import { ProConVoteController } from './pro-con-vote.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
-import { ProConDiscussionsModule } from 'src/modules/pro-con-discussions/pro-con-discussions.module';
+import { ProConDiscussionsHelperService } from '../pro-con-discussions-helper/pro-con-discussions-helper.service';
 
 @Module({
   controllers: [ProConVoteController],
-  providers: [ProConVoteService],
-  imports: [PrismaModule, forwardRef(() => ProConDiscussionsModule)],
+  providers: [ProConVoteService, ProConDiscussionsHelperService],
+  imports: [PrismaModule],
   exports: [ProConVoteService],
 })
 export class ProConVoteModule {}

--- a/src/modules/pro-con-vote/pro-con-vote.service.ts
+++ b/src/modules/pro-con-vote/pro-con-vote.service.ts
@@ -1,11 +1,6 @@
-import {
-  ConflictException,
-  forwardRef,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { ProConDiscussionsService } from './../pro-con-discussions/pro-con-discussions.service';
+import { ProConDiscussionsHelperService } from '../pro-con-discussions-helper/pro-con-discussions-helper.service';
 import { CreateProConVoteDto } from './dto/create-pro-con-vote.dto';
 import { UpdateProConVoteDto } from './dto/update-pro-con-vote.dto';
 
@@ -13,8 +8,7 @@ import { UpdateProConVoteDto } from './dto/update-pro-con-vote.dto';
 export class ProConVoteService {
   constructor(
     private prisma: PrismaService,
-    @Inject(forwardRef(() => ProConDiscussionsService))
-    private proConDiscussionsService: ProConDiscussionsService,
+    private proConDiscussionsHelperService: ProConDiscussionsHelperService,
   ) {}
 
   async create(
@@ -23,7 +17,7 @@ export class ProConVoteService {
     postId: number,
   ) {
     const proConDiscussions =
-      await this.proConDiscussionsService.findOneByPostIdThrow(postId);
+      await this.proConDiscussionsHelperService.findOneByPostIdThrow(postId);
 
     const existProConVote = await this.findExistingVote(
       userId,
@@ -56,7 +50,7 @@ export class ProConVoteService {
 
   async findOneByUserIdAndPostId(userId: number, postId: number) {
     const proConDiscussions =
-      await this.proConDiscussionsService.findOneByPostId(postId);
+      await this.proConDiscussionsHelperService.findOneByPostId(postId);
 
     if (!proConDiscussions) {
       return null;
@@ -123,7 +117,7 @@ export class ProConVoteService {
     postId: number,
   ) {
     const proConDiscussions =
-      await this.proConDiscussionsService.findOneByPostIdThrow(postId);
+      await this.proConDiscussionsHelperService.findOneByPostIdThrow(postId);
 
     const proConVote = await this.prisma.proConVote.update({
       where: {


### PR DESCRIPTION
### 개발내용
- #32 
- 순환 참조로 오류 파악에 혼선이 생긴다고 판단되어 순환참조를 발생시키는 findOneByPostId, findOneByPostIdThrow를 별도의 helper 서비스로 분리
- 그 외의 특이사항
  - findAll method에서 posts.map(this.convertPostToReposnse) 부분에서 this가 undefiend로 나오는 이슈 발생
  - 아래와 같이 constructor에 bind 추가
  ```ts
    constructor(
      private prisma: PrismaService,
      private postService: PostsService,
      private proConVoteService: ProConVoteService,
      @Inject(forwardRef(() => CommentsService))
      private commentsService: CommentsService,
    ) {
      this.convertPostToReposnse = this.convertPostToReposnse.bind(this);
    }
  ```
  
Resolves:  #32  
