### PR TITLE
[Feature] 토론 검색기능 추가, pageInfo 통일

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch", "fullTextIndex"]
 }
 
 datasource db {
@@ -95,6 +96,8 @@ model Post {
   ProConDiscussion ProConDiscussion?
   CommentDislike   CommentDislike[]
   PostLike         PostLike[]
+
+  @@fulltext([title])
 }
 
 model BookDiscussion {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,7 +23,7 @@ import { AppService } from './app.service';
 import { ThrottlerBehindProxyGuard } from './shared/guards/throttler-behind-proxy.guard';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
-// import { SearchModule } from './modules/search/search.module';
+import { SearchModule } from './modules/search/search.module';
 
 @Module({
   imports: [
@@ -53,7 +53,7 @@ import { join } from 'path';
       limit: 20,
     }),
 
-    // SearchModule,
+    SearchModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/book-discussions/book-discussions.controller.ts
+++ b/src/modules/book-discussions/book-discussions.controller.ts
@@ -64,7 +64,7 @@ export class BookDiscussionsController {
 
     return {
       posts,
-      pagesInfo: {
+      pageInfo: {
         page,
         totalCount,
         currentCount: posts.length,

--- a/src/modules/book-discussions/book-discussions.module.ts
+++ b/src/modules/book-discussions/book-discussions.module.ts
@@ -18,5 +18,6 @@ import { AuthModule } from '../auth/auth.module';
     PostLikesModule,
     AuthModule,
   ],
+  exports: [BookDiscussionsService],
 })
 export class BookDiscussionsModule {}

--- a/src/modules/book-discussions/book-discussions.service.ts
+++ b/src/modules/book-discussions/book-discussions.service.ts
@@ -86,13 +86,21 @@ export class BookDiscussionsService {
     return { ...this.convertPostToReposnse(post), comments: [] };
   }
 
-  async findAll(limit: number, offset: number, userId: number) {
-    const posts = await this.prisma.post.findMany({
-      where: {
-        NOT: {
-          BookDiscussion: null,
-        },
+  async findAll(
+    limit: number,
+    offset: number,
+    userId: number,
+    query: string = null,
+  ) {
+    const where = {
+      NOT: {
+        BookDiscussion: null,
       },
+      ...(query !== null && { title: { contains: query } }),
+    };
+
+    const posts = await this.prisma.post.findMany({
+      where,
       take: limit,
       skip: offset,
       include: {

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -72,7 +72,7 @@ export class CommentsController {
 
     return {
       comments,
-      pagesInfo: {
+      pageInfo: {
         page,
         totalCount,
         currentCount: comments.length,

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -8,14 +8,12 @@ import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment, User, CommentLike, CommentDislike } from '@prisma/client';
 import { ProConVoteService } from '../pro-con-vote/pro-con-vote.service';
-import { PostsService } from 'src/modules/posts/posts.service';
 
 @Injectable()
 export class CommentsService {
   constructor(
     private prisma: PrismaService,
     private proConVoteService: ProConVoteService,
-    private postsService: PostsService,
   ) {}
 
   convertPostToReposnse(
@@ -81,7 +79,7 @@ export class CommentsService {
       createdAt: comment.createdAt.toISOString(),
       updatedAt: comment.updatedAt.toISOString(),
       ...(proConVote && {
-        isAgree: proConVote.isAgree,
+        isPro: proConVote.isPro,
       }),
     };
   }
@@ -174,7 +172,7 @@ export class CommentsService {
       createdAt: comment.createdAt.toISOString(),
       updatedAt: comment.updatedAt.toISOString(),
       ...(proConVote && {
-        isAgree: proConVote.isAgree,
+        isPro: proConVote.isPro,
       }),
     };
   }

--- a/src/modules/pro-con-discussions/pro-con-discussions.service.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.service.ts
@@ -110,11 +110,17 @@ export class ProConDiscussionsService {
   }
 
   //ToDo: 대표 두명, 찬반 카운트
-  async findAll(limit: number, offset: number) {
-    const posts = await this.prisma.post.findMany({
-      where: {
-        NOT: { ProConDiscussion: null },
+  async findAll(limit: number, offset: number, query: string = null) {
+    const where = {
+      NOT: {
+        ProConDiscussion: null,
       },
+      ...(query !== null && { title: { contains: query } }),
+    };
+    console.log(where);
+
+    const posts = await this.prisma.post.findMany({
+      where,
       take: limit,
       skip: offset,
       include: {

--- a/src/modules/pro-con-vote/pro-con-vote.service.ts
+++ b/src/modules/pro-con-vote/pro-con-vote.service.ts
@@ -113,6 +113,15 @@ export class ProConVoteService {
     const proConDiscussions =
       await this.proConDiscussionsHelperService.findOneByPostIdThrow(postId);
 
+    const existProConVote = await this.findExistingVote(
+      userId,
+      proConDiscussions.id,
+    );
+
+    if (!existProConVote) {
+      throw new ConflictException('기존에 찬성반대한적이 없습니다.');
+    }
+
     const proConVote = await this.prisma.proConVote.update({
       where: {
         userId_proConDiscussionId: {

--- a/src/modules/search/dto/create-search.dto.ts
+++ b/src/modules/search/dto/create-search.dto.ts
@@ -1,0 +1,1 @@
+export class CreateSearchDto {}

--- a/src/modules/search/dto/update-search.dto.ts
+++ b/src/modules/search/dto/update-search.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSearchDto } from './create-search.dto';
+
+export class UpdateSearchDto extends PartialType(CreateSearchDto) {}

--- a/src/modules/search/entities/search.entity.ts
+++ b/src/modules/search/entities/search.entity.ts
@@ -1,0 +1,1 @@
+export class Search {}

--- a/src/modules/search/search.controller.spec.ts
+++ b/src/modules/search/search.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+
+describe('SearchController', () => {
+  let controller: SearchController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SearchController],
+      providers: [SearchService],
+    }).compile();
+
+    controller = module.get<SearchController>(SearchController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/search/search.controller.ts
+++ b/src/modules/search/search.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Get, Query, Req } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { PaginationQueryDto } from 'src/shared/dto/pagenation-query.dto';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import UserRequest from '../auth/types/user-request.interface';
+import { AuthService } from '../auth/auth.service';
+import { Public } from '../auth/decorators/public.decorator';
+
+@ApiTags('sarch')
+@Controller('search')
+export class SearchController {
+  constructor(
+    private readonly searchService: SearchService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @ApiBearerAuth()
+  @ApiQuery({ name: 'limit', type: Number, required: false })
+  @ApiQuery({ name: 'page', type: Number, required: false })
+  @ApiQuery({ name: 'type', type: String, required: false })
+  @Public()
+  @Get()
+  async searchAll(
+    @Query('query') query: string,
+    @Query('type') type: string,
+    @Req() request: UserRequest,
+    @Query() paginationQueryDto?: PaginationQueryDto,
+  ) {
+    const token = request.headers.authorization?.replace('Bearer ', '');
+    const user = await this.authService.getUserFromToken(token);
+
+    console.log(paginationQueryDto, paginationQueryDto.page);
+
+    const { page, limit } = paginationQueryDto;
+    const offset = (page - 1) * limit;
+    const { proConResults, bookResults, totalCount } =
+      await this.searchService.searchAll(
+        limit,
+        offset,
+        user?.id || -1,
+        query,
+        type,
+      );
+
+    return {
+      proConResults,
+      bookResults,
+      pageInfo: {
+        page,
+        totalCount,
+        currentCount: proConResults.length + bookResults.length,
+        totalPage: Math.ceil(totalCount / limit),
+      },
+    };
+  }
+}

--- a/src/modules/search/search.module.ts
+++ b/src/modules/search/search.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { SearchController } from './search.controller';
+import { AuthModule } from '../auth/auth.module';
+import { ProConDiscussionsModule } from '../pro-con-discussions/pro-con-discussions.module';
+import { BookDiscussionsModule } from '../book-discussions/book-discussions.module';
+
+@Module({
+  controllers: [SearchController],
+  providers: [SearchService],
+  imports: [AuthModule, ProConDiscussionsModule, BookDiscussionsModule],
+})
+export class SearchModule {}

--- a/src/modules/search/search.service.spec.ts
+++ b/src/modules/search/search.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SearchService],
+    }).compile();
+
+    service = module.get<SearchService>(SearchService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/search/search.service.ts
+++ b/src/modules/search/search.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { BookDiscussionsService } from '../book-discussions/book-discussions.service';
+import { ProConDiscussionsService } from '../pro-con-discussions/pro-con-discussions.service';
+
+@Injectable()
+export class SearchService {
+  constructor(
+    private proConDiscussionsService: ProConDiscussionsService,
+    private bookDiscussionsService: BookDiscussionsService,
+  ) {}
+
+  async searchAll(
+    limit: number,
+    offset: number,
+    userId: number,
+    query: string,
+    type: string,
+  ) {
+    let proConResults = [];
+    let bookResults = [];
+    if (!type || type === 'proCon') {
+      proConResults = await this.proConDiscussionsService
+        .findAll(limit, offset, query)
+        .then(({ posts }) => posts);
+    }
+    if (!type || type === 'book') {
+      bookResults = await this.bookDiscussionsService
+        .findAll(limit, offset, userId, query)
+        .then(({ posts }) => posts);
+    }
+
+    const totalCount = proConResults.length + bookResults.length;
+    return { proConResults, bookResults, totalCount };
+  }
+}


### PR DESCRIPTION
### 개발내용
- 토론 검색기능 추가
- 검색어가 제목에 포함되는 경우 응답으로 가도록 구현
- query params의 type에 따라 구분지어 동작
  - type이 없는경우: 통합검색 
  - type=book: 독서토론검색 
  - type=proCon: 찬반토론 검색
- pagesInfo에서 pageInfo 전체 통일

### 그 외
- pro-con-vote PATCH 메소드에서 찬반 토론이 없는 경우 예외처리 추가