### PR TITLE
[Feature] 마이페이지 기능 구현

### DIFF
--- a/src/modules/auth/guards/optional-jwt-auth.guard.ts
+++ b/src/modules/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,51 @@
+// optional-jwt-auth.guard.ts
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // Public 라우트인 경우, 토큰이 제공되었을 때에만 검증을 수행하고, 그렇지 않으면 검증을 생략합니다.
+    if (isPublic) {
+      const request = context.switchToHttp().getRequest();
+      if (!request.headers.authorization) {
+        return true;
+      }
+    }
+
+    // Public 라우트가 아닌 경우, 무조건 토큰을 검증합니다.
+    return super.canActivate(context);
+  }
+
+  handleRequest(
+    err: Error,
+    user: any,
+    info: any,
+    context: ExecutionContext,
+    status?: any,
+  ) {
+    // Public 라우트인 경우, 에러가 발생하더라도 그냥 무시하고 사용자를 반환합니다.
+    // 이렇게 하면, 토큰이 제공되었을 때에만 사용자 정보를 얻을 수 있습니다.
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return user;
+    }
+
+    // Public 라우트가 아닌 경우, 에러가 발생하면 예외를 던집니다.
+    return super.handleRequest(err, user, info, context, status);
+  }
+}

--- a/src/modules/book-discussions/book-discussions.controller.ts
+++ b/src/modules/book-discussions/book-discussions.controller.ts
@@ -51,16 +51,14 @@ export class BookDiscussionsController {
     @Query() paginationQueryDto: PaginationQueryDto,
     @Req() request: UserRequest,
   ) {
-    const token = request.headers.authorization?.replace('Bearer ', '');
-    const user = await this.authService.getUserFromToken(token);
     const { page, limit } = paginationQueryDto;
     const offset = (page - 1) * limit;
 
-    const { posts, totalCount } = await this.bookDiscussionsService.findAll(
+    const { posts, totalCount } = await this.bookDiscussionsService.findAll({
       limit,
       offset,
-      user?.id || -1,
-    );
+      userId: request.user?.id || -1,
+    });
 
     return {
       posts,

--- a/src/modules/book-discussions/types/book-discussion.type.ts
+++ b/src/modules/book-discussions/types/book-discussion.type.ts
@@ -20,20 +20,10 @@ export interface ResponseType {
   };
 }
 
-// Post & {
-//     User: {
-//         username: string;
-//     };
-//     BookDiscussion: (BookDiscussion & {
-//         Book: Book;
-//     })[];
-//     Comment: (Comment & {
-//         User: {
-//             username: string;
-//         };
-//         _count: {
-//             CommentLike: number;
-//             CommentDislike: number;
-//         };
-//     })[];
-// }
+export interface FindAllType {
+  limit: number;
+  offset: number;
+  userId: number;
+  query?: string;
+  myPostsOnly?: boolean;
+}

--- a/src/modules/book-discussions/utils/postUtils.ts
+++ b/src/modules/book-discussions/utils/postUtils.ts
@@ -1,0 +1,50 @@
+import { Post, BookDiscussion, Book, Comment, PostLike } from '@prisma/client';
+
+export const postToResponse = (
+  post: Post & {
+    BookDiscussion: BookDiscussion & {
+      Book: Book;
+    };
+    Comment?: Comment[];
+    User: {
+      username: string;
+    };
+    PostLike: PostLike[];
+    _count: { PostLike: number };
+  },
+) => ({
+  id: post.id,
+  author: post.User.username,
+  title: post.title,
+  content: post.content,
+  views: post.views,
+  likeCount: post._count.PostLike,
+  createdAt: post.createdAt.toISOString(),
+  updatedAt: post.updatedAt.toISOString(),
+  book: post.BookDiscussion.Book,
+  ...(post.Comment && { comments: post.Comment }),
+  postLikedByUser: post.PostLike.length > 0 ? true : false,
+});
+
+export const prismaPostInclude = (userId: number) => ({
+  BookDiscussion: {
+    include: {
+      Book: true,
+    },
+  },
+  User: {
+    select: {
+      username: true,
+    },
+  },
+  PostLike: {
+    where: {
+      userId,
+    },
+  },
+  _count: {
+    select: {
+      PostLike: true,
+    },
+  },
+});

--- a/src/modules/comments/comments.controller.ts
+++ b/src/modules/comments/comments.controller.ts
@@ -81,6 +81,26 @@ export class CommentsController {
     };
   }
 
+  @ApiQuery({ name: 'limit', type: Number, required: true })
+  @ApiQuery({ name: 'page', type: Number, required: true })
+  @ApiBearerAuth()
+  @Get('user')
+  async findAllByUserId(
+    @Query() { page, limit }: PaginationQueryDto,
+    @Req() request: UserRequest,
+  ) {
+    const { comments, pageInfo } = await this.commentsService.findAllByUserId(
+      request.user.id,
+      page,
+      limit,
+    );
+
+    return {
+      comments,
+      pageInfo,
+    };
+  }
+
   @Get(':id')
   @Public()
   async findOne(@Param('id', ParseIntPipe) id: number) {
@@ -119,7 +139,7 @@ export class CommentsController {
   ) {
     return await this.commentsLikeService.create({
       commentId: id,
-      userId: Number(request.user.id),
+      userId: request.user.id,
     });
   }
 
@@ -131,7 +151,7 @@ export class CommentsController {
     @Param('id', ParseIntPipe) id: number,
     @Req() request: UserRequest,
   ) {
-    await this.commentsLikeService.removeThrow(id, Number(request.user.id));
+    await this.commentsLikeService.removeThrow(id, request.user.id);
   }
 
   @ApiBearerAuth()
@@ -143,7 +163,7 @@ export class CommentsController {
   ) {
     return await this.commentsDislikeService.create({
       commentId: id,
-      userId: Number(request.user.id),
+      userId: request.user.id,
     });
   }
 
@@ -155,6 +175,6 @@ export class CommentsController {
     @Param('id', ParseIntPipe) id: number,
     @Req() request: UserRequest,
   ) {
-    await this.commentsDislikeService.removeThrow(id, Number(request.user.id));
+    await this.commentsDislikeService.removeThrow(id, request.user.id);
   }
 }

--- a/src/modules/comments/comments.module.ts
+++ b/src/modules/comments/comments.module.ts
@@ -6,9 +6,10 @@ import { CommentsController } from './comments.controller';
 import { CommentsLikeModule } from 'src/modules/comments-like/comments-like.module';
 import { CommentsDislikeModule } from 'src/modules/comments-dislike/comments-dislike.module';
 import { ProConVoteModule } from '../pro-con-vote/pro-con-vote.module';
+import { PaginationService } from '../pagination/pagination.service';
 
 @Module({
-  providers: [CommentsService],
+  providers: [CommentsService, PaginationService],
   exports: [CommentsService],
   imports: [
     PrismaModule,

--- a/src/modules/comments/dto/comment-response.dto.ts
+++ b/src/modules/comments/dto/comment-response.dto.ts
@@ -1,0 +1,17 @@
+export class PageInfoDto {
+  page: number;
+  totalCount: number;
+  currentCount: number;
+  totalPage: number;
+}
+
+export class CommentResponseDto {
+  id: number;
+  author: string;
+  content: string;
+  like: number;
+  dislike: number;
+  createdAt: string;
+  updatedAt: string;
+  isPro?: boolean;
+}

--- a/src/modules/comments/dto/query-params.dto.ts
+++ b/src/modules/comments/dto/query-params.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CommentsQueryParamsDto {
+  @IsNumber()
+  @IsNotEmpty()
+  postId: number;
+}

--- a/src/modules/comments/utils/comments.util.ts
+++ b/src/modules/comments/utils/comments.util.ts
@@ -1,0 +1,42 @@
+import { Comment, CommentDislike, CommentLike } from '@prisma/client';
+
+export function convertCommentToReposnse(
+  comment: Comment & {
+    User: {
+      username: string;
+    };
+    _count: {
+      CommentLike: number;
+      CommentDislike: number;
+    };
+    CommentLike: CommentLike[];
+    CommentDislike: CommentDislike[];
+  },
+  userId: number,
+) {
+  return {
+    id: comment.id,
+    author: comment.User.username,
+    content: comment.content,
+    like: comment._count.CommentDislike,
+    dislike: comment._count.CommentLike,
+    createdAt: comment.createdAt.toISOString(),
+    updatedAt: comment.updatedAt.toISOString(),
+    likedByUser: comment.CommentLike.some((like) => like.userId === userId),
+    dislikedBytUser: comment.CommentDislike.some(
+      (dislike) => dislike.userId === userId,
+    ),
+  };
+}
+export const prismaCommentInclude = () => ({
+  ProConDiscussion: {
+    include: {
+      ProConVote: true,
+    },
+  },
+  User: {
+    select: {
+      username: true,
+    },
+  },
+});

--- a/src/modules/mypage/mypage.controller.spec.ts
+++ b/src/modules/mypage/mypage.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MypageController } from './mypage.controller';
+import { MypageService } from './mypage.service';
+
+describe('MypageController', () => {
+  let controller: MypageController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MypageController],
+      providers: [MypageService],
+    }).compile();
+
+    controller = module.get<MypageController>(MypageController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/mypage/mypage.controller.ts
+++ b/src/modules/mypage/mypage.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { MypageService } from './mypage.service';
+import UserRequest from '../auth/types/user-request.interface';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('mypage')
+@Controller('mypage')
+export class MypageController {
+  constructor(private readonly mypageService: MypageService) {}
+
+  @Get()
+  @ApiBearerAuth()
+  findOne(@Req() request: UserRequest) {
+    return this.mypageService.findOne(request.user.id);
+  }
+}

--- a/src/modules/mypage/mypage.module.ts
+++ b/src/modules/mypage/mypage.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MypageService } from './mypage.service';
+import { MypageController } from './mypage.controller';
+import { UsersModule } from '../users/users.module';
+import { BookDiscussionsModule } from '../book-discussions/book-discussions.module';
+import { ProConDiscussionsModule } from '../pro-con-discussions/pro-con-discussions.module';
+import { CommentsModule } from '../comments/comments.module';
+
+@Module({
+  controllers: [MypageController],
+  providers: [MypageService],
+  imports: [
+    UsersModule,
+    BookDiscussionsModule,
+    ProConDiscussionsModule,
+    CommentsModule,
+  ],
+})
+export class MypageModule {}

--- a/src/modules/mypage/mypage.service.spec.ts
+++ b/src/modules/mypage/mypage.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MypageService } from './mypage.service';
+
+describe('MypageService', () => {
+  let service: MypageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MypageService],
+    }).compile();
+
+    service = module.get<MypageService>(MypageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/mypage/mypage.service.ts
+++ b/src/modules/mypage/mypage.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { BookDiscussionsService } from '../book-discussions/book-discussions.service';
+import { ProConDiscussionsService } from '../pro-con-discussions/pro-con-discussions.service';
+import { CommentsService } from '../comments/comments.service';
+
+@Injectable()
+export class MypageService {
+  constructor(
+    private bookDiscussionsService: BookDiscussionsService,
+    private proConDiscussionsService: ProConDiscussionsService,
+    private commentsService: CommentsService,
+  ) {}
+
+  async findOne(userId: number) {
+    // 독서토론
+    const bookDiscussions = await this.bookDiscussionsService.findAll({
+      userId,
+      offset: 0,
+      limit: 2,
+      myPostsOnly: true,
+    });
+    // 찬반토론
+    const proConDiscussions = await this.proConDiscussionsService.findAll({
+      userId,
+      offset: 0,
+      limit: 2,
+      myPostsOnly: true,
+    });
+
+    // 댓글 목록
+    const comments = await this.commentsService.findAllByUserId(userId, 1, 2);
+
+    return {
+      bookDiscussions: [...bookDiscussions.posts],
+      proConDiscussions: [...proConDiscussions.posts],
+      comments: [...comments.comments],
+    };
+  }
+}

--- a/src/modules/pagination/pagination.service.spec.ts
+++ b/src/modules/pagination/pagination.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaginationService } from './pagination.service';
+
+describe('PaginationServiceService', () => {
+  let service: PaginationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PaginationService],
+    }).compile();
+
+    service = module.get<PaginationService>(PaginationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/pagination/pagination.service.ts
+++ b/src/modules/pagination/pagination.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PaginationService {
+  createPageInfo(
+    totalCount: number,
+    page: number,
+    limit: number,
+    length: number,
+  ) {
+    const totalPage = Math.ceil(totalCount / limit);
+
+    return {
+      page,
+      limit,
+      totalCount,
+      totalPage,
+      currentCount: length,
+    };
+  }
+
+  getOffset(page: number, limit: number) {
+    return (page - 1) * limit;
+  }
+}

--- a/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
@@ -48,13 +48,17 @@ export class ProConDiscussionsController {
   @ApiQuery({ name: 'page', type: Number, required: true })
   @Public()
   @Get()
-  async findAll(@Query() paginationQueryDto: PaginationQueryDto) {
+  async findAll(
+    @Query() paginationQueryDto: PaginationQueryDto,
+    @Req() request: UserRequest,
+  ) {
     const { page, limit } = paginationQueryDto;
     const offset = (page - 1) * limit;
-    const { posts, totalCount } = await this.proConDiscussionsService.findAll(
+    const { posts, totalCount } = await this.proConDiscussionsService.findAll({
       limit,
       offset,
-    );
+      userId: request?.user?.id,
+    });
     return {
       posts,
       pageInfo: {

--- a/src/modules/pro-con-discussions/types/pro-con-discussion.type.ts
+++ b/src/modules/pro-con-discussions/types/pro-con-discussion.type.ts
@@ -1,0 +1,7 @@
+export interface FindAllType {
+  limit: number;
+  offset: number;
+  userId?: number;
+  query?: string;
+  myPostsOnly?: boolean;
+}

--- a/src/modules/pro-con-discussions/utils/pro-con-discussion.util.ts
+++ b/src/modules/pro-con-discussions/utils/pro-con-discussion.util.ts
@@ -1,0 +1,12 @@
+export const prismaPostInclude = () => ({
+  ProConDiscussion: {
+    include: {
+      ProConVote: true,
+    },
+  },
+  User: {
+    select: {
+      username: true,
+    },
+  },
+});

--- a/src/modules/search/search.service.ts
+++ b/src/modules/search/search.service.ts
@@ -25,12 +25,12 @@ export class SearchService {
 
     if (!type || type === 'proCon') {
       proConResults = await this.proConDiscussionsService
-        .findAll(limit, offset, query)
+        .findAll({ limit, offset, query })
         .then(({ posts }) => posts);
     }
     if (!type || type === 'book') {
       bookResults = await this.bookDiscussionsService
-        .findAll(limit, offset, userId, query)
+        .findAll({ limit, offset, userId, query })
         .then(({ posts }) => posts);
     }
 

--- a/src/shared/dto/pagenation-query.dto.ts
+++ b/src/shared/dto/pagenation-query.dto.ts
@@ -4,6 +4,7 @@ import { IsNumber, IsOptional, Min, Max } from 'class-validator';
 export class PaginationQueryDto {
   @IsOptional()
   @Type(() => Number)
+  @Transform(({ value }) => parseInt(value, 10))
   @IsNumber()
   @Min(1)
   page = 1;


### PR DESCRIPTION
### 개발 내용
- #3 
- 마이페이지 기능 추가
  - 최신 댓글 2개
  - 최신 독서토론 게시글 2개
  - 최신  찬반토론 게시글 2개
- optional-jwt-auth.guard
  - @public 인 경우에도 로그인 정보가 필요한 경우가 발생하여, @public인 경우 토큰 확인 후 없는 경우 오류가 발생하지 않도록 구현
- proConDiscussionService findAll의 나의 post만 받아오기 myPostsOnly params 추가
- bookDiscussionService findAll의 나의 post만 받아오기 myPostsOnly params 추가

- pagenationService 추가
  - 모든 서비스에서 pagenation이 반복된다고 판단되어 분리 생성

- 공통
   - prisma incude 반복 사용되는 부분을 utils 파일로 분리
   - Reposnse 로 변환하는 로직부분도 utils로 분리