### PR TITLE
[Refactor] 게시글 좋아요 응답 좋아요 수로 수정, 게시글 미존재 예외처리 추가

### DIFF
--- a/src/modules/post-likes/post-likes.controller.ts
+++ b/src/modules/post-likes/post-likes.controller.ts
@@ -5,7 +5,6 @@ import {
   Delete,
   ParseIntPipe,
   Req,
-  HttpCode,
 } from '@nestjs/common';
 import { PostLikesService } from './post-likes.service';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -27,11 +26,10 @@ export class PostLikesController {
 
   @Delete()
   @ApiBearerAuth()
-  @HttpCode(204)
   async remove(
     @Param('postId', ParseIntPipe) postId: number,
     @Req() request: UserRequest,
   ) {
-    await this.postLikesService.remove(postId, request.user.id);
+    return await this.postLikesService.remove(postId, request.user.id);
   }
 }

--- a/src/modules/post-likes/post-likes.controller.ts
+++ b/src/modules/post-likes/post-likes.controller.ts
@@ -5,18 +5,21 @@ import {
   Delete,
   ParseIntPipe,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import { PostLikesService } from './post-likes.service';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import UserRequest from '../auth/types/user-request.interface';
+import { ParamPostExistGuard } from '../posts/guards/param-post-exits.guard';
 
 @ApiTags('likes')
 @Controller('likes/:postId')
 export class PostLikesController {
   constructor(private readonly postLikesService: PostLikesService) {}
 
-  @Post()
   @ApiBearerAuth()
+  @Post()
+  @UseGuards(ParamPostExistGuard)
   async create(
     @Param('postId', ParseIntPipe) postId: number,
     @Req() request: UserRequest,
@@ -24,8 +27,9 @@ export class PostLikesController {
     return await this.postLikesService.create(postId, request.user.id);
   }
 
-  @Delete()
   @ApiBearerAuth()
+  @Delete()
+  @UseGuards(ParamPostExistGuard)
   async remove(
     @Param('postId', ParseIntPipe) postId: number,
     @Req() request: UserRequest,

--- a/src/modules/post-likes/post-likes.module.ts
+++ b/src/modules/post-likes/post-likes.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PostLikesService } from './post-likes.service';
 import { PostLikesController } from './post-likes.controller';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { PostsModule } from '../posts/posts.module';
 
 @Module({
   controllers: [PostLikesController],
   providers: [PostLikesService],
-  imports: [PrismaModule],
+  imports: [PrismaModule, PostsModule],
   exports: [PostLikesService],
 })
 export class PostLikesModule {}

--- a/src/modules/post-likes/post-likes.service.ts
+++ b/src/modules/post-likes/post-likes.service.ts
@@ -30,7 +30,7 @@ export class PostLikesService {
       },
     });
 
-    return this.countByPostId(postId);
+    return { likeCount: await this.countByPostId(postId) };
   }
 
   async findOne(postId: number, userId: number) {
@@ -60,7 +60,7 @@ export class PostLikesService {
       },
     });
 
-    return this.countByPostId(postId);
+    return { likeCount: await this.countByPostId(postId) };
   }
 
   async countByPostId(postId: number) {

--- a/src/modules/post-likes/post-likes.service.ts
+++ b/src/modules/post-likes/post-likes.service.ts
@@ -58,4 +58,12 @@ export class PostLikesService {
       },
     });
   }
+
+  async countByPostId(postId: number) {
+    return await this.prisma.postLike.count({
+      where: {
+        postId,
+      },
+    });
+  }
 }

--- a/src/modules/post-likes/post-likes.service.ts
+++ b/src/modules/post-likes/post-likes.service.ts
@@ -16,7 +16,7 @@ export class PostLikesService {
       throw new ConflictException('이미 좋아요한 게시글입니다.');
     }
 
-    return await this.prisma.postLike.create({
+    await this.prisma.postLike.create({
       data: {
         userId,
         postId,
@@ -29,6 +29,8 @@ export class PostLikesService {
         },
       },
     });
+
+    return this.countByPostId(postId);
   }
 
   async findOne(postId: number, userId: number) {
@@ -49,7 +51,7 @@ export class PostLikesService {
       throw new NotFoundException('게시글 좋아요를 찾을 수 없습니다.');
     }
 
-    return await this.prisma.postLike.delete({
+    await this.prisma.postLike.delete({
       where: {
         userId_postId: {
           userId,
@@ -57,6 +59,8 @@ export class PostLikesService {
         },
       },
     });
+
+    return this.countByPostId(postId);
   }
 
   async countByPostId(postId: number) {

--- a/src/modules/posts/guards/param-post-exits.guard.ts
+++ b/src/modules/posts/guards/param-post-exits.guard.ts
@@ -1,0 +1,26 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PostsService } from '../posts.service';
+
+@Injectable()
+export class ParamPostExistGuard implements CanActivate {
+  constructor(private readonly postService: PostsService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const postId = Number(request.params.postId || -1); // postId가 어디에서 받아오는지에 따라 수정 필요
+
+    const post = await this.postService.findOne(postId);
+
+    // post가 존재하지 않을 경우 예외 던지기
+    if (!post) {
+      throw new NotFoundException(`${postId} postId found`);
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
### 이슈번호
- #72 

### 개발내용
- postid 기분 좋아요수 구하는 함수 countByPostId 추가
  ```ts
  async countByPostId(postId: number) {
    return await this.prisma.postLike.count({
      where: {
        postId,
      },
    });
  }
  ``` 
- 게시글 좋아요 생성/삭제 service 반환값 수정
   ```ts
    return { likeCount: await this.countByPostId(postId) };
   ```

- 게시글 좋아요 삭제 상태코드 수정
  - 204 -> 200

- 게시글 존재 여부 판단 추가
  - ParamPostExistGuard 추가 
    ```ts
    export class ParamPostExistGuard implements CanActivate {
      constructor(private readonly postService: PostsService) {}
    
      async canActivate(context: ExecutionContext): Promise<boolean> {
        const request = context.switchToHttp().getRequest();
        const postId = Number(request.params.postId || -1); // postId가 어디에서 받아오는지에 따라 수정 필요
    
        const post = await this.postService.findOne(postId);
    
        // post가 존재하지 않을 경우 예외 던지기
        if (!post) {
          throw new NotFoundException(`${postId} postId found`);
        }
    
        return true;
      }
    }
    ```