### PR TITLE
[Bug] 댓글 좋아요/싫어요 여부 기준 유저 수정

### DIFF
--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -99,8 +99,6 @@ export class CommentsService {
       },
     });
 
-    console.log(comments);
-
     const commentsWithProConVote = await Promise.all(
       comments.map(async (comment) => {
         const proConVote =
@@ -110,7 +108,7 @@ export class CommentsService {
           );
 
         return {
-          ...convertCommentToReposnse(comment, comment.authorId),
+          ...convertCommentToReposnse(comment, userId),
           ...(proConVote && {
             isPro: proConVote.isPro,
           }),


### PR DESCRIPTION
### 관련 이슈
- #91 

### 버그 내용
- 본인 이 외의 사람이 작성한 댓글에 대해서 좋아요/싫어요시 정상적으로 좋아요/싫어요 여부가 나오지 않는 이슈
- 기준 유저가 댓글 작성자로 잘 못되어있어, 로그인 유저로 수정