### PR TITLE
[Bug] 찬반 토론 본인 찬성 반대 여부 누락 수정

### DIFF
--- a/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
+++ b/src/modules/pro-con-discussions/pro-con-discussions.controller.ts
@@ -44,6 +44,7 @@ export class ProConDiscussionsController {
     );
   }
 
+  @ApiBearerAuth()
   @ApiQuery({ name: 'limit', type: Number, required: true })
   @ApiQuery({ name: 'page', type: Number, required: true })
   @Public()
@@ -57,7 +58,7 @@ export class ProConDiscussionsController {
     const { posts, totalCount } = await this.proConDiscussionsService.findAll({
       limit,
       offset,
-      userId: request?.user?.id,
+      userId: request?.user?.id || -1,
     });
     return {
       posts,

--- a/src/modules/pro-con-vote/pro-con-vote.service.ts
+++ b/src/modules/pro-con-vote/pro-con-vote.service.ts
@@ -62,6 +62,22 @@ export class ProConVoteService {
     });
   }
 
+  async findFirstByUserIdAndPostId(userId: number, postId: number) {
+    const proConDiscussions =
+      await this.proConDiscussionsHelperService.findOneByPostId(postId);
+
+    if (!proConDiscussions) {
+      return null;
+    }
+
+    return await this.prisma.proConVote.findFirst({
+      where: {
+        userId,
+        proConDiscussionId: proConDiscussions.id,
+      },
+    });
+  }
+
   async findFirstPro(proConDiscussionId: number) {
     return await this.prisma.proConVote.findFirst({
       where: {


### PR DESCRIPTION
### 관련 이슈
- #93 

### 개발내용
- pro-con-vote
  - findFirstByUserIdAndPostId 추가: 기존 find는 없는 경우 throw를 발생시켜 별도로 구현
- pro-con-discussion
  - 본인 투표 여부, 찬성 반대 추가 (투표를 하지 않은 경우 null)
     ```ts
      const proConVote = await this.proConVoteService.findFirstByUserIdAndPostId(
        userId,
        post.id,
      );
      const isPro = proConVote?.isPro || null; // 없는 경우 null
      const isVote = isPro !== null; // 찬반 유무로 투표여부 판단
     ```