### PR TITLE
[Bug] BookDiscussion not null 추가

### DIFF
--- a/src/modules/book-discussions/book-discussions.service.ts
+++ b/src/modules/book-discussions/book-discussions.service.ts
@@ -105,11 +105,14 @@ export class BookDiscussionsService {
   }: FindAllType) {
     const queryString = query !== null && {
       title: {
-        search: `*${query}*`,
+        contains: query,
       },
     };
 
     const where = {
+      NOT: {
+        BookDiscussion: null,
+      },
       ...queryString,
       PostLike: {
         some: {


### PR DESCRIPTION
### 관련 이슈
- #107 

### 수정 내용
- book이 미포함된 게시글 제외 
   ```ts
    NOT: {
      BookDiscussion: null,
    },
   ``` 