### PR TITLE
[Feature] 댓글 알림 삭제, 토론 타입 추가

### DIFF
--- a/src/modules/notification/notification.controller.ts
+++ b/src/modules/notification/notification.controller.ts
@@ -5,6 +5,9 @@ import {
   Param,
   Req,
   ParseIntPipe,
+  Delete,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { NotificationService } from './notification.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
@@ -25,5 +28,12 @@ export class NotificationController {
   @Patch(':id/read')
   async markAsRead(@Param('id', ParseIntPipe) id: number) {
     return await this.notificationService.markAsRead(id);
+  }
+
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete(':id')
+  async remove(@Param('id', ParseIntPipe) id: number) {
+    await this.notificationService.remove(id);
   }
 }

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateNotificationDto } from './dto/create-notification.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
@@ -47,5 +47,25 @@ export class NotificationService {
       updatedAt: notification.Comment.updatedAt,
       readStatus: notification.readStatus,
     };
+  }
+
+  async findOne(notificationId: number) {
+    return await this.prisma.commentNotification.findFirst({
+      where: { id: notificationId },
+    });
+  }
+
+  async remove(notificationId: number) {
+    const notification = await this.findOne(notificationId);
+
+    if (!notification) {
+      throw new NotFoundException(
+        `Not found notification: [${notificationId}]`,
+      );
+    }
+
+    return await this.prisma.commentNotification.delete({
+      where: { id: notificationId },
+    });
   }
 }


### PR DESCRIPTION
### 관련 이슈
- #122 

### 개발 내용
- NotificationService 
  - findOne: id 기준 요소 1개 찾기
  - remove: id 기준 요소 삭제 (id 미존재시 404 error)
    
- NotificationController
  -  remove: Delete Method처리 -> 204 NonContent 반환


- getNotificationsForUser
  - 토론 타입 필드 `type` 반환 추가
    - proCon : 찬반 토론
    - book: 독서토론
    - 그 외:  null (현재는 미존재)