### PR TITLE
[Feature] 댓글 최신순 정렬 추라, 댓글 알림 리스트 수정

### DIFF
--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -15,7 +15,7 @@ export class NotificationService {
   async getNotificationsForUser(userId: number) {
     const commentNotifications = await this.prisma.commentNotification.findMany(
       {
-        where: { userId, readStatus: false },
+        where: { userId },
         include: {
           Comment: {
             include: {

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -16,6 +16,9 @@ export class NotificationService {
     const commentNotifications = await this.prisma.commentNotification.findMany(
       {
         where: { userId },
+        orderBy: {
+          createdAt: 'desc',
+        },
         include: {
           Comment: {
             include: {

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -45,8 +45,8 @@ export class NotificationService {
       })();
 
       return {
-        type,
         id: notification.id,
+        type,
         postId: notification.Comment.postId,
         commentId: notification.commentId,
         content: notification.Comment.content,
@@ -61,11 +61,35 @@ export class NotificationService {
     const notification = await this.prisma.commentNotification.update({
       where: { id: notificationId },
       data: { readStatus: true },
-      include: { Comment: true },
+      include: {
+        Comment: {
+          include: {
+            Post: {
+              select: {
+                BookDiscussion: true,
+                ProConDiscussion: true,
+              },
+            },
+          },
+        },
+      },
     });
+
+    const type = (() => {
+      if (notification.Comment.Post.BookDiscussion !== null) {
+        return 'book';
+      }
+
+      if (notification.Comment.Post.ProConDiscussion !== null) {
+        return 'proCon';
+      }
+
+      return null;
+    })();
 
     return {
       id: notification.id,
+      type,
       postId: notification.Comment.postId,
       commentId: notification.commentId,
       content: notification.Comment.content,


### PR DESCRIPTION
### 관련 이슈
- #122 

### 수정 내용
- markAsRead
  - 응답에 토론 type이 포함되도록 수정
- getNotificationsForUser
  - 최신순 정렬 추가
  - 읽음 처리된 목록도 포함되도록 reacdStatus: false 삭제  