### PR TITLE
[Bug] JWT username validate에서  email로 수정, username 중복 확인 추가

### DIFF
--- a/src/modules/auth/strategys/jwt.strategy.ts
+++ b/src/modules/auth/strategys/jwt.strategy.ts
@@ -15,7 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    const user = await this.usersService.findOne(payload.username);
+    const user = await this.usersService.findOneByEmail(payload.email);
     return user;
   }
 }

--- a/src/modules/users/constants/messages.ts
+++ b/src/modules/users/constants/messages.ts
@@ -6,6 +6,7 @@ export const VALIDATE_ERROR_MESSAGE = {
     '신규 비밀번호가 올바르지 않습니다. 최소 8자, 최대 20자, 최소 하나의 문자, 숫자, 특수문자를 포함해주세요.',
   PASSWORD_NOT_MATCH: `기존 패스워드와 일치하지 않습니다. 다시 확인해주세요`,
   SAME_AS_THE_OLD_PASSWORD: '기존 패스워드와 동일합니다. 다르게 설정해주세요',
+  DUPLICATE_USERNAME: '이미 존재하는 유저 이름입니다.',
 } as const;
 
 export const FILE_ERROR_MESSAGE = {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -2,7 +2,6 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -114,6 +113,16 @@ export class UsersService {
   }
 
   async update(id: number, updateUserDto: UpdateUserDto) {
+    if (updateUserDto.username !== undefined) {
+      const isExists = await this.prisma.user.findFirst({
+        where: { username: updateUserDto.username },
+      });
+
+      if (isExists) {
+        throw new ConflictException(VALIDATE_ERROR_MESSAGE.DUPLICATE_USERNAME);
+      }
+    }
+
     const user = await this.prisma.user.update({
       where: { id },
       data: updateUserDto,


### PR DESCRIPTION
### 관련 이슈
- #131 

### 수정 내용
- username 변경시 token 인증 오류 이슈
   - JWT username 확인에서 email확인으로 수정

### 기타 수정 내용
- username 중복 확인 추가
   -  username 중복시 500에러로 처리되어 409 에러로 변경